### PR TITLE
Allow to set metrics server port and private key from client

### DIFF
--- a/Lachain.CommunicationHub.Native.nuspec
+++ b/Lachain.CommunicationHub.Native.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Lachain.CommunicationHub.Native</id>
-    <version>0.0.63</version>
+    <version>0.0.64</version>
     <authors>Skird</authors>
     <owners>Skird</owners>
     <license type="expression">MIT</license>

--- a/Lachain.CommunicationHub.Net/Hub.cs
+++ b/Lachain.CommunicationHub.Net/Hub.cs
@@ -47,18 +47,17 @@ namespace Lachain.CommunicationHub.Net
             );
         }
 
-        public static void Start(string bootstrapAddress,  string privKeyHex)
+        public static void Start(string bootstrapAddress,  byte[] privKey)
         {
             unsafe
             {
                 var bootstrapAddressBytes = Encoding.UTF8.GetBytes(bootstrapAddress);
-                var privKeyHexBytes = Encoding.UTF8.GetBytes(privKeyHex);
                 fixed (byte* bootstrapAddressPtr = bootstrapAddressBytes)
-                fixed (byte* privKeyHexPtr = privKeyHexBytes)
+                fixed (byte* privKeyPtr = privKey)
                 {
                     Imports.StartHub.Value(
                         bootstrapAddressPtr, bootstrapAddressBytes.Length,
-                        privKeyHexPtr, privKeyHexBytes.Length
+                        privKeyPtr, privKey.Length
                     );
                 }
             }

--- a/Lachain.CommunicationHub.Net/Hub.cs
+++ b/Lachain.CommunicationHub.Net/Hub.cs
@@ -181,10 +181,9 @@ namespace Lachain.CommunicationHub.Net
                 fixed (byte* ptr = privHex)
                 {
                     len = Imports.GenerateNewKeyHub.Value(ptr, len);
-                    privHex.Take(len);
                 }
             }
-            return Encoding.UTF8.GetString(privHex);
+            return Encoding.UTF8.GetString(privHex.Take(len).ToArray());
         }
     }
 }

--- a/Lachain.CommunicationHub.Net/Hub.cs
+++ b/Lachain.CommunicationHub.Net/Hub.cs
@@ -59,13 +59,13 @@ namespace Lachain.CommunicationHub.Net
             }
         }
 
-        public static bool Init(byte[] signature)
+        public static bool Init(byte[] signature, int hubMetricsPort)
         {
             unsafe
             {
                 fixed (byte* signaturePtr = signature)
                 {
-                    return Imports.HubInit.Value(signaturePtr, signature.Length) == 1;
+                    return Imports.HubInit.Value(signaturePtr, signature.Length, hubMetricsPort) == 1;
                 }
             }
         }

--- a/Lachain.CommunicationHub.Net/Hub.cs
+++ b/Lachain.CommunicationHub.Net/Hub.cs
@@ -14,7 +14,7 @@ namespace Lachain.CommunicationHub.Net
         internal readonly Lazy<HubInit> HubInit;
         internal readonly Lazy<HubGetKey> HubGetKey;
         internal readonly Lazy<StartProfiler> StartProfiler;
-        internal readonly Lazy<HubGenerateNewKey> GenerateNewKey;
+        internal readonly Lazy<HubGenerateNewKey> GenerateNewKeyHub;
 
 
         const string Lib = "hub";
@@ -35,7 +35,7 @@ namespace Lachain.CommunicationHub.Net
             HubInit = LazyDelegate<HubInit>();
             HubGetKey = LazyDelegate<HubGetKey>();
             StartProfiler = LazyDelegate<StartProfiler>();
-            GenerateNewKey = LazyDelegate<HubGenerateNewKey>();
+            GenerateNewKeyHub = LazyDelegate<HubGenerateNewKey>();
         }
 
         Lazy<TDelegate> LazyDelegate<TDelegate>()
@@ -173,19 +173,15 @@ namespace Lachain.CommunicationHub.Net
 
         public static string GenerateNewHubKey()
         {
-            byte[] privHex;
-            int len;
+            const int maxBuffer = 2000;
+            byte[] privHex = new byte[maxBuffer];
+            int len = maxBuffer;
             unsafe
             {
                 fixed (byte* ptr = privHex)
                 {
-                    len = Imports.GenerateNewKey.Value(ptr, 0);
-                }
-                if (len > privHex.Length)
-                    privHex = new byte[len];
-                fixed (byte* ptr = privHex)
-                {
-                    len = Imports.GenerateNewKey.Value(ptr, len);
+                    len = Imports.GenerateNewKeyHub.Value(ptr, len);
+                    privHex.Take(len);
                 }
             }
             return Encoding.UTF8.GetString(privHex);

--- a/Lachain.CommunicationHub.Net/Interop.cs
+++ b/Lachain.CommunicationHub.Net/Interop.cs
@@ -8,7 +8,7 @@ namespace Lachain.CommunicationHub.Net
     public unsafe delegate int HubGetKey(byte* buffer, int maxLength);
 
     [SymbolName("Init")]
-    public unsafe delegate int HubInit(byte* signature, int signatureLength);
+    public unsafe delegate int HubInit(byte* signature, int signatureLength, int hubMetricsPort);
 
     [SymbolName("SendMessage")]
     public unsafe delegate int HubSendMessage(

--- a/Lachain.CommunicationHub.Net/Interop.cs
+++ b/Lachain.CommunicationHub.Net/Interop.cs
@@ -2,7 +2,7 @@ namespace Lachain.CommunicationHub.Net
 {
     [SymbolName("StartHub")]
     public unsafe delegate int HubStart(byte* bootstrapAddress, int bootstrapAddressLen,
-                                        byte* privKeyHex, int privKeyHexLen);
+                                        byte* privKey, int privKeyLen);
 
     [SymbolName("GetKey")]
     public unsafe delegate int HubGetKey(byte* buffer, int maxLength);

--- a/Lachain.CommunicationHub.Net/Interop.cs
+++ b/Lachain.CommunicationHub.Net/Interop.cs
@@ -1,8 +1,8 @@
 namespace Lachain.CommunicationHub.Net
 {
     [SymbolName("StartHub")]
-    public unsafe delegate int HubStart(byte* bootstrapAddress, int bootstrapAddressLen);
-
+    public unsafe delegate int HubStart(byte* bootstrapAddress, int bootstrapAddressLen,
+                                        byte* privKeyHex, int privKeyHexLen);
 
     [SymbolName("GetKey")]
     public unsafe delegate int HubGetKey(byte* buffer, int maxLength);
@@ -27,4 +27,7 @@ namespace Lachain.CommunicationHub.Net
     
     [SymbolName("StartProfiler")]
     public delegate int StartProfiler();
+
+    [SymbolName("GenerateNewKey")]
+    public unsafe delegate int HubGenerateNewKey(byte* str, int len);
 }

--- a/Lachain.CommunicationHub.Net/Lachain.CommunicationHub.Net.csproj
+++ b/Lachain.CommunicationHub.Net/Lachain.CommunicationHub.Net.csproj
@@ -5,7 +5,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>8</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>0.0.13</Version>
+        <Version>0.0.14</Version>
         <Title>Lachain.CommunicationHub.Net</Title>
         <Authors>Skird</Authors>
         <Description>Netstandard 2.1 wrapper for Lachain communication hub library. Use Lachain.CommunicationHub.Native package to get platform specific binaries for common platforms.</Description>

--- a/embedded_hub.go
+++ b/embedded_hub.go
@@ -10,11 +10,8 @@ import (
 	"fmt"
 	"github.com/enriquebris/goconcurrentqueue"
 	"github.com/juju/loggo"
-<<<<<<< HEAD
-=======
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
->>>>>>> 9584713... add ability to set private key from client
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"lachain-communication-hub/config"
 	"lachain-communication-hub/peer_service"
@@ -43,19 +40,16 @@ func ProcessMessage(msg []byte) {
 }
 
 //export StartHub
-func StartHub(bootstrapAddress *C.char, bootstrapAddressLen C.int, privKeyHex *C.char, privKeyHexLen C.int) {
+func StartHub(bootstrapAddress *C.char, bootstrapAddressLen C.int, privKey unsafe.Pointer, privKeyLen C.int) {
 	mutex.Lock()
 	defer mutex.Unlock()
 	config.SetBootstrapAddress(C.GoStringN(bootstrapAddress, bootstrapAddressLen))
-	prvBytes, err := hex.DecodeString(C.GoStringN(privKeyHex, privKeyHexLen))
-	if err != nil {
-		panic(err)
-	}
-	privKey, err2 := crypto.UnmarshalPrivateKey(prvBytes)
+	prvBytes := C.GoBytes(privKey, privKeyLen)
+	prv, err2 := crypto.UnmarshalPrivateKey(prvBytes)
 	if err2 != nil {
 		panic(err2)
 	}
-	localPeer = peer_service.New(privKey, ProcessMessage)
+	localPeer = peer_service.New(prv, ProcessMessage)
 }
 
 //export GetKey

--- a/embedded_hub.go
+++ b/embedded_hub.go
@@ -4,14 +4,19 @@ package main
 import "C"
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"github.com/enriquebris/goconcurrentqueue"
 	"github.com/juju/loggo"
+<<<<<<< HEAD
+=======
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+>>>>>>> 9584713... add ability to set private key from client
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"lachain-communication-hub/config"
-	"lachain-communication-hub/host"
 	"lachain-communication-hub/peer_service"
 	"net"
 	"net/http"
@@ -38,12 +43,19 @@ func ProcessMessage(msg []byte) {
 }
 
 //export StartHub
-func StartHub(bootstrapAddress *C.char, bootstrapAddressLen C.int) {
+func StartHub(bootstrapAddress *C.char, bootstrapAddressLen C.int, privKeyHex *C.char, privKeyHexLen C.int) {
 	mutex.Lock()
 	defer mutex.Unlock()
 	config.SetBootstrapAddress(C.GoStringN(bootstrapAddress, bootstrapAddressLen))
-	priv_key := host.GetPrivateKeyForHost("_h1")
-	localPeer = peer_service.New(priv_key, ProcessMessage)
+	prvBytes, err := hex.DecodeString(C.GoStringN(privKeyHex, privKeyHexLen))
+	if err != nil {
+		panic(err)
+	}
+	privKey, err2 := crypto.UnmarshalPrivateKey(prvBytes)
+	if err2 != nil {
+		panic(err2)
+	}
+	localPeer = peer_service.New(privKey, ProcessMessage)
 }
 
 //export GetKey
@@ -187,4 +199,29 @@ func StartProfiler() C.int {
 	return C.int(<-portChannel)
 }
 
+//export GenerateNewKey
+func GenerateNewKey(buffer *C.char, bufferLen C.int) C.int {
+	prv, _, err := crypto.GenerateECDSAKeyPair(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	id, _ := peer.IDFromPrivateKey(prv)
+
+	prvBytes, err := crypto.MarshalPrivateKey(prv)
+	if err != nil {
+		panic(err)
+	}
+
+	prvHex := fmt.Sprintf("%s,%s", hex.EncodeToString(prvBytes), id)
+
+	if len(prvHex) > int(bufferLen) {
+		return C.int(len(prvHex))
+	}
+
+	C.memcpy(unsafe.Pointer(&prvHex), unsafe.Pointer(buffer), C.ulong(len(prvHex)))
+	return C.int(len(prvHex))
+}
+
 func main() {}
+

--- a/embedded_hub.go
+++ b/embedded_hub.go
@@ -200,7 +200,7 @@ func StartProfiler() C.int {
 }
 
 //export GenerateNewKey
-func GenerateNewKey(buffer *C.char, bufferLen C.int) C.int {
+func GenerateNewKey(buffer unsafe.Pointer, bufferLen C.int) C.int {
 	prv, _, err := crypto.GenerateECDSAKeyPair(rand.Reader)
 	if err != nil {
 		panic(err)
@@ -219,8 +219,9 @@ func GenerateNewKey(buffer *C.char, bufferLen C.int) C.int {
 		return C.int(len(prvHex))
 	}
 
-	C.memcpy(unsafe.Pointer(&prvHex), unsafe.Pointer(buffer), C.ulong(len(prvHex)))
-	return C.int(len(prvHex))
+	data := []byte(prvHex)
+	C.memcpy(buffer, unsafe.Pointer(&data[0]), C.size_t(len(data)))
+	return C.int(len(data))
 }
 
 func main() {}

--- a/embedded_hub.go
+++ b/embedded_hub.go
@@ -103,14 +103,14 @@ func GetMessages(buffer unsafe.Pointer, maxLength C.int) C.int {
 }
 
 //export Init
-func Init(signaturePtr unsafe.Pointer, signatureLength C.int) C.int {
+func Init(signaturePtr unsafe.Pointer, signatureLength C.int, metricsPort C.int) C.int {
 	mutex.Lock()
 	defer mutex.Unlock()
 	log.Tracef("Received: Init Request")
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
 		for {
-			err := http.ListenAndServe(":7072", nil)
+			err := http.ListenAndServe(fmt.Sprintf(":%d", int(metricsPort)), nil)
 			if err != nil {
 				log.Errorf("Error while serving metrics: %v", err)
 			}


### PR DESCRIPTION
Now all data required to start hub can be configured in client's config.json file,  hub doesn't require separate configuration 